### PR TITLE
_pkg.sh: convert Unix EOLs to CRLF to make Notepad happy

### DIFF
--- a/_pkg.sh
+++ b/_pkg.sh
@@ -16,6 +16,7 @@ _cdo="$(pwd)"
 
 if [ "${_NAM}" != "${_UNIPKG}" ]; then
 
+  find "${_DST}" \( -name '*.txt' -o -name '*.md' -o -name '*.rst' \) -exec unix2dos --quiet --keepdate '{}' +
   find "${_DST}" -depth -type d -exec touch -c -r "$1" '{}' +
   chmod -R a+rw-s,go-w "${_DST}"
   # NOTE: Not effective on MSYS2:


### PR DESCRIPTION
- Restore CRLF in README.txt, COPYING.txt, etc.

This reverts commit be6bfb21. Notepad in recent systems can properly process LF-only lines but we're releasing a product that can run on legacy systems where that may not be true.

Fixes https://github.com/curl/curl-for-win/issues/42
Closes #xxxx
