### PR TITLE
switch to zlib-ng by default (from classic zip)

### DIFF
--- a/_build.sh
+++ b/_build.sh
@@ -9,11 +9,11 @@ set -o xtrace -o errexit -o nounset; [ -n "${BASH:-}${ZSH_NAME:-}" ] && set -o p
 # Build configuration environment variables:
 #
 # CW_BLD
-#      List of components to build. E.g. 'curl' or 'zlib libssh2 curl' or 'none'.
+#      List of components to build. E.g. 'curl' or 'zlibng libssh2 curl' or 'none'.
 #      Optional. Default: (all)
 #
 # CW_GET
-#      List of components to (re-)download. E.g. 'zlib curl' or 'none'.
+#      List of components to (re-)download. E.g. 'zlibng curl' or 'none'.
 #      Optional. Default: (all)
 #
 # CW_NOGET
@@ -38,7 +38,7 @@ set -o xtrace -o errexit -o nounset; [ -n "${BASH:-}${ZSH_NAME:-}" ] && set -o p
 #        nobrotli   build without brotli
 #        nozstd     build without zstd
 #        nozlib     build without zlib
-#        zlibng     build with zlib-ng instead of zlib
+#        zlibold    build with zlib (classic) instead of zlib-ng
 #        noftp      build without FTP/FTPS support
 #        nohttp     build without HTTP and proxy support
 #        nocookie   build without cookie support

--- a/_dl.sh
+++ b/_dl.sh
@@ -657,10 +657,10 @@ fi
 export _DEPS='curl'
 
 if [[ ! "${_CONFIG}" =~ (zero|nozlib) ]]; then
-  if [[ "${_CONFIG}" = *'zlibng'* ]]; then
-    _DEPS+=' zlibng'
-  else
+  if [[ "${_CONFIG}" = *'zlibold'* ]]; then
     _DEPS+=' zlibold'
+  else
+    _DEPS+=' zlibng'
   fi
 fi
 


### PR DESCRIPTION
zlib-ng is a modernized, optimized fork of the venerable zlib library.

It builds cleanly, without tricks and hacks. It's an overall smoother
experience, and should also give better performance, though for curl
the difference is expected to be minor.

Build times are a bit higher than classic zlib, but the absolute
difference is negligible.

It makes binaries a 1.5% larger (as tested with Windows 32-bit, libssh):

binary      |  with zlib | with zlib-ng | increase
:---------- | ---------: | -----------: | -------:
curl.exe    |    4178432 |      4236800 |    +1.4%
libcurl.dll |    3698176 |      3757056 |    +1.6%

---

TODO:
- [ ] curl PR:
```diff
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -140,7 +140,7 @@ jobs:
             "${DOCKER_IMAGE}" \
             sh -c ./_ci-linux-debian.sh
 
-  win-gcc-libssh-zlibng-x86:
+  win-gcc-libssh-x86:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
```
